### PR TITLE
[FEAT] Gap-based numbering 방식을 통한 플레이리스트 순서 변경

### DIFF
--- a/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
@@ -9,4 +9,5 @@ public class EntityConstants {
     /*PLAY LIST*/
     public static final int MAX_PLAY_LIST_TITLE = 40;
     public static final int MAX_PLAY_LIST_DESCRIPTION = 200;
+    public static final long GAP = 9214157878975800L;
 }

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/req/PlayListItemProjection.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/req/PlayListItemProjection.java
@@ -1,0 +1,12 @@
+package com.naver.playlist.domain.dto.playlist.req;
+
+import lombok.*;
+
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlayListItemProjection {
+
+    private Long playListItemId;
+}

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/req/ReorderPlayListItemsRequest.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/req/ReorderPlayListItemsRequest.java
@@ -1,0 +1,13 @@
+package com.naver.playlist.domain.dto.playlist.req;
+
+import lombok.*;
+
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ReorderPlayListItemsRequest {
+
+    private Long playListItemId;
+    private Long position;
+}

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListReOrderResponse.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListReOrderResponse.java
@@ -1,0 +1,16 @@
+package com.naver.playlist.domain.dto.playlist.res;
+
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlayListReOrderResponse {
+    private boolean isSuccess;
+    private List<ReorderPlayListItemsRequest> playListItems;
+}

--- a/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
+++ b/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
@@ -9,6 +9,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.Comment;
 
 @Entity
 @Getter
@@ -19,7 +20,17 @@ import lombok.Setter;
                 @UniqueConstraint(
                         name = "uk_playlist_music",
                         columnNames = { "playListId", "musicId" }
+                ),
+                @UniqueConstraint(
+                        name = "uk_playlist_position",
+                        columnNames = { "playListId", "position" }
                 )
+        },
+        indexes = {
+            @Index(
+                    name = "idx_playlist_position",
+                    columnList = "playListId, position"
+            )
         }
 )
 public class PlayListItem extends BaseEntity {
@@ -28,6 +39,10 @@ public class PlayListItem extends BaseEntity {
     @GeneratedValue
     @Column(name = "playListItemId")
     private Long id;
+
+    @Column(nullable = false)
+    @Comment("정렬용 숫자 값으로 같은 플레이리스트 내에서 유일해야 한다")
+    private Long position;
 
     @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/naver/playlist/domain/repository/JdbcBulkRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/JdbcBulkRepository.java
@@ -1,5 +1,6 @@
 package com.naver.playlist.domain.repository;
 
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -7,6 +8,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -18,6 +20,13 @@ public class JdbcBulkRepository {
           (play_list_id, member_id, title, description, created_date, last_modified_date)
         VALUES
           (:id, :memberId, :title, :description, :createdDate, :lastModifiedDate)
+    """;
+
+    private static final String UPDATE_SQL = """
+        UPDATE play_list_item
+           SET position           = :position,
+               last_modified_date = :lastModifiedDate
+         WHERE play_list_item_id  = :id
     """;
 
     private final NamedParameterJdbcTemplate jdbcTemplate;
@@ -35,5 +44,18 @@ public class JdbcBulkRepository {
                 .toArray(SqlParameterSource[]::new);
 
         jdbcTemplate.batchUpdate(INSERT_SQL, batch);
+    }
+
+    public void bulkUpdatePosition(List<ReorderPlayListItemsRequest> requests) {
+        LocalDateTime now = LocalDateTime.now();
+
+        SqlParameterSource[] batch = requests.stream()
+                .map(r -> new MapSqlParameterSource()
+                        .addValue("id",               r.getPlayListItemId())
+                        .addValue("position",         r.getPosition())
+                        .addValue("lastModifiedDate", now))
+                .toArray(SqlParameterSource[]::new);
+
+        jdbcTemplate.batchUpdate(UPDATE_SQL, batch);
     }
 }

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
@@ -1,5 +1,6 @@
 package com.naver.playlist.domain.repository;
 
+import com.naver.playlist.domain.dto.playlist.req.PlayListItemProjection;
 import com.naver.playlist.domain.entity.playlist.PlayListItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,4 +16,9 @@ public interface PlayListItemRepository extends JpaRepository<PlayListItem, Long
             "join fetch pl.member m " +
             "where pli.id in :ids")
     List<PlayListItem> findPlayListItemForUpdate(List<Long> ids);
+
+    @Query("select pli.id as playListItemId, pli.position as position from PlayListItem pli " +
+            "where pli.playList.id = :playListId " +
+            "order by pli.position")
+    List<PlayListItemProjection> findPlayListItemAll(Long playListId);
 }

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
@@ -1,0 +1,18 @@
+package com.naver.playlist.domain.repository;
+
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PlayListItemRepository extends JpaRepository<PlayListItem, Long> {
+
+    @Query("select pli from PlayListItem pli " +
+            "join fetch pli.playList pl " +
+            "join fetch pl.member m " +
+            "where pli.id in :ids")
+    List<PlayListItem> findPlayListItemForUpdate(List<Long> ids);
+}

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
@@ -1,9 +1,0 @@
-package com.naver.playlist.domain.repository;
-
-import com.naver.playlist.domain.entity.playlist.PlayList;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface PlayListRepository extends JpaRepository<PlayList, Long> {
-}

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
@@ -1,0 +1,9 @@
+package com.naver.playlist.domain.repository;
+
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlayListRepository extends JpaRepository<PlayList, Long> {
+}

--- a/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
@@ -1,16 +1,22 @@
 package com.naver.playlist.domain.service;
 
+import com.naver.playlist.domain.dto.playlist.req.PlayListItemProjection;
 import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.dto.playlist.res.PlayListReOrderResponse;
 import com.naver.playlist.domain.entity.playlist.PlayList;
 import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.naver.playlist.domain.repository.JdbcBulkRepository;
 import com.naver.playlist.domain.repository.PlayListItemRepository;
 import com.naver.playlist.web.exception.entity.PlayListException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import static com.naver.playlist.domain.constant.EntityConstants.GAP;
 import static com.naver.playlist.web.exception.ExceptionType.*;
 
 @Service
@@ -18,47 +24,101 @@ import static com.naver.playlist.web.exception.ExceptionType.*;
 @Transactional
 public class PlayListItemService {
 
+    private final JdbcBulkRepository jdbcBulkRepository;
     private final PlayListItemRepository playListItemRepository;
 
-    public void reorder(
+    public PlayListReOrderResponse reorder(
             Long playListId,
             Long memberId,
             List<ReorderPlayListItemsRequest> dto
     ) {
         // 1️⃣ 조회할 아이디 추출
-        List<Long> ids = dto.stream()
-                .map(ReorderPlayListItemsRequest::getPlayListItemId)
-                .toList();
+        List<Long> ids = extractIds(dto);
 
         // 2️⃣ 페치조인 + IN 쿼리 조회 - PlayListItem + PlayList + Member
         List<PlayListItem> playListItems =
                 playListItemRepository.findPlayListItemForUpdate(ids);
 
         // 3️⃣ 개수 불일치 → 일부 곡이 존재하지 않음
+        validateExistence(dto, playListItems);
+
+        // 4️⃣ 플레이리스트 ID 검증 (모든 곡이 같은 플레이리스트 소속인지)
+        validatePlayList(playListId, playListItems);
+
+        // 5️⃣ 멤버 검증 (해당 플레이리스트 소유자인지)
+        validateMember(memberId, playListItems.get(0).getPlayList());
+
+        // 6️⃣ 벌크 업데이트 - 실패시 전체 재오더링, 예외를 던지는 이유는 리렌더링 후 클라이언트에서 재조정해야하기 때문
+        return bulkUpdate(dto, playListId);
+    }
+
+    private List<Long> extractIds(List<ReorderPlayListItemsRequest> dto) {
+        return dto.stream()
+                .map(ReorderPlayListItemsRequest::getPlayListItemId)
+                .toList();
+    }
+
+    private void validateExistence(
+            List<ReorderPlayListItemsRequest> dto,
+            List<PlayListItem> playListItems
+    ) {
         if (dto.size() != playListItems.size()) {
             throw new PlayListException(
                     PLAY_LIST_ITEM_NOT_EXIST.getCode(),
                     PLAY_LIST_ITEM_NOT_EXIST.getErrorMessage()
             );
         }
+    }
 
-        // 4️⃣ 플레이리스트 ID 검증 (모든 곡이 같은 플레이리스트 소속인지)
-        boolean hasWrongPlayList =
-                playListItems.stream()
-                        .anyMatch(playListItem -> !playListItem.getPlayList().getId().equals(playListId));
+    private void validatePlayList(
+            Long playListId,
+            List<PlayListItem> playListItems
+    ) {
+        boolean hasWrongPlayList = playListItems.stream()
+                .anyMatch(item -> !item.getPlayList().getId().equals(playListId));
 
         if (hasWrongPlayList) {
             throw new PlayListException(
                     PLAY_LIST_NOT_MATCH_ITEM.getCode(),
-                    PLAY_LIST_NOT_MATCH_ITEM.getErrorMessage());
+                    PLAY_LIST_NOT_MATCH_ITEM.getErrorMessage()
+            );
         }
+    }
 
-        // 5️⃣ 멤버 검증 (해당 플레이리스트 소유자인지)
-        PlayList firstPlayList = playListItems.get(0).getPlayList();
-        if (!firstPlayList.getMember().getId().equals(memberId)) {
+    private void validateMember(Long memberId, PlayList playList) {
+        if (!playList.getMember().getId().equals(memberId)) {
             throw new PlayListException(
                     PLAY_LIST_AUTH_INVALID.getCode(),
-                    PLAY_LIST_AUTH_INVALID.getErrorMessage());
+                    PLAY_LIST_AUTH_INVALID.getErrorMessage()
+            );
         }
+    }
+
+    private PlayListReOrderResponse bulkUpdate(
+            List<ReorderPlayListItemsRequest> dto,
+            Long playListId
+    ) {
+        try {
+            jdbcBulkRepository.bulkUpdatePosition(dto);
+            return new PlayListReOrderResponse(true, dto);
+        } catch (DuplicateKeyException ex) {
+            List<ReorderPlayListItemsRequest> reorderList = reorderingPositions(playListId);
+            jdbcBulkRepository.bulkUpdatePosition(reorderList);
+            return new PlayListReOrderResponse(false, reorderList);
+        }
+    }
+
+    private List<ReorderPlayListItemsRequest> reorderingPositions(Long playListId) {
+        List<PlayListItemProjection> playListItemAll =
+                playListItemRepository.findPlayListItemAll(playListId);
+
+        List<ReorderPlayListItemsRequest> reorderList = new ArrayList<>(playListItemAll.size());
+        long position = GAP;
+
+        for (PlayListItemProjection p : playListItemAll) {
+            reorderList.add(new ReorderPlayListItemsRequest(p.getPlayListItemId(), position));
+            position += GAP;
+        }
+        return reorderList;
     }
 }

--- a/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
@@ -1,0 +1,64 @@
+package com.naver.playlist.domain.service;
+
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.naver.playlist.domain.repository.PlayListItemRepository;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.naver.playlist.web.exception.ExceptionType.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PlayListItemService {
+
+    private final PlayListItemRepository playListItemRepository;
+
+    public void reorder(
+            Long playListId,
+            Long memberId,
+            List<ReorderPlayListItemsRequest> dto
+    ) {
+        // 1️⃣ 조회할 아이디 추출
+        List<Long> ids = dto.stream()
+                .map(ReorderPlayListItemsRequest::getPlayListItemId)
+                .toList();
+
+        // 2️⃣ 페치조인 + IN 쿼리 조회 - PlayListItem + PlayList + Member
+        List<PlayListItem> playListItems =
+                playListItemRepository.findPlayListItemForUpdate(ids);
+
+        // 3️⃣ 개수 불일치 → 일부 곡이 존재하지 않음
+        if (dto.size() != playListItems.size()) {
+            throw new PlayListException(
+                    PLAY_LIST_ITEM_NOT_EXIST.getCode(),
+                    PLAY_LIST_ITEM_NOT_EXIST.getErrorMessage()
+            );
+        }
+
+        // 4️⃣ 플레이리스트 ID 검증 (모든 곡이 같은 플레이리스트 소속인지)
+        boolean hasWrongPlayList =
+                playListItems.stream()
+                        .anyMatch(playListItem -> !playListItem.getPlayList().getId().equals(playListId));
+
+        if (hasWrongPlayList) {
+            throw new PlayListException(
+                    PLAY_LIST_NOT_MATCH_ITEM.getCode(),
+                    PLAY_LIST_NOT_MATCH_ITEM.getErrorMessage());
+        }
+
+        // 5️⃣ 멤버 검증 (해당 플레이리스트 소유자인지)
+        PlayList firstPlayList = playListItems.get(0).getPlayList();
+        if (!firstPlayList.getMember().getId().equals(memberId)) {
+            throw new PlayListException(
+                    PLAY_LIST_AUTH_INVALID.getCode(),
+                    PLAY_LIST_AUTH_INVALID.getErrorMessage());
+        }
+    }
+}

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -102,6 +102,9 @@ public class PlayListController {
      *     - playListItem과 playList가 올바르게 매핑되어 있는지 확인
      *     - playList와 회원이 올바르게 매핑되어 있는지 확인
      * 4. 데이터 배치 처리
+     * 5. 만약 장애 발생시 리오더링을 진행 후 클라이언트에 알림
+     * 6. 리오더링 과정에서 DTO 프로젝션을 통해서 성능 최적화
+     * 7. 클라이언트는 재시도 요청 보냄
      * */
     @PatchMapping("/{playlistId}/items/order")
     public void reorderItems(

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -3,13 +3,15 @@ package com.naver.playlist.web.controller;
 import com.naver.playlist.domain.dto.playlist.req.CreatePlayListItemRequest;
 import com.naver.playlist.domain.dto.playlist.req.DeletePlayListItemRequest;
 import com.naver.playlist.domain.dto.playlist.req.PlayListCreateRequest;
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import com.naver.playlist.domain.service.PlayListItemService;
 import com.naver.playlist.domain.service.PlayListService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
+import java.util.List;
 
 import static com.naver.playlist.domain.validator.MemberValidator.validateMemberId;
 import static com.naver.playlist.domain.validator.PlayListValidator.validatePlayListCreate;
@@ -20,9 +22,12 @@ import static com.naver.playlist.domain.validator.PlayListValidator.validatePlay
 public class PlayListController {
 
     private final PlayListService playListService;
+    private final PlayListItemService playListItemService;
 
     /*
      * 플레이리스트 생성
+     * 플레이리스트 생성은 대규모로 이어지고 있음을 가정한다.
+     * 레디스와 벌크 인서트를 통해 플레이리스트 생성 성능을 최적화한다.
      * 1. DTO 유효성 검사
      * 2. 사용자 인증 정보 조회
      * 3. 플레이리스트 생성 정보를 인증정보와 함께 레디스에 스냅샷(백업) 생성
@@ -81,6 +86,31 @@ public class PlayListController {
             @RequestBody DeletePlayListItemRequest dto
     ) {
         return;
+    }
+
+    /*
+     * 플레이리스트 순서 변경
+     * 플레이리스트 순서 변경은 오직 플레이리스트 작성자만 가능하다.
+     * Gap-based numbering 방식을 통해 순서를 구성한다.
+     * 순서 변경의 경우 클라이언트에서 체크 후 전송되어짐을 가정한다.
+     * 즉, 노래의 순서가 변경되었을 경우, 이 변환된 순서 값을 클라이언트에서 감지하여 서버로 전송한다.
+     * 전체 리오더링도 여기에 포함된다.
+     * 서버는 배치 업데이트를 진행한다.
+     * 1. DTO 유효성 검사
+     * 2. 사용자 인증 정보 조회
+     * 3. 업데이트 할 데이터 조회 - 이떄 쿼리 최적화를 통해 IN 쿼리로 진행한다.
+     *     - playListItem과 playList가 올바르게 매핑되어 있는지 확인
+     *     - playList와 회원이 올바르게 매핑되어 있는지 확인
+     * 4. 데이터 배치 처리
+     * */
+    @PatchMapping("/{playlistId}/items/order")
+    public void reorderItems(
+            HttpServletRequest request,
+            @PathVariable Long playlistId,
+            @RequestBody List<ReorderPlayListItemsRequest> dto
+    ) {
+        Long memberId = validateMemberId(request);
+        playListItemService.reorder(playlistId, memberId, dto);
     }
 }
 

--- a/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
+++ b/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
@@ -18,6 +18,13 @@ public enum ExceptionType {
     /* MEMBER Exception */
     MEMBER_AUTH_ID_INVALID( 10000, "회원 인증정보가 적절하지 않습니다."),
 
+    /* PLAYLIST Exception */
+    PLAY_LIST_NOT_EXIST( 20000, "플레이리스트가 존재하지 않습니다."),
+    PLAY_LIST_AUTH_INVALID( 20001, "플레이리스트 접근 권한이 없습니다."),
+    PLAY_LIST_ITEM_NOT_EXIST( 20002, "플레이리스트 노래가 존재하지 않습니다."),
+    PLAY_LIST_NOT_MATCH_ITEM( 20003, "같은 플레이리스트의 노래만 업데이트 해주세요."),
+
+
     /* DTO Exception */
     PLAY_LIST_TITLE_INVALID( 80000, "플레이리스트 제목을 40자 이내로 작성해주세요."),
     PLAY_LIST_DESCRIPTION_INVALID( 80000, "플레이리스트 내용은 1000자 이내로 작성해주세요.");

--- a/src/test/java/com/naver/playlist/PlayListTest.java
+++ b/src/test/java/com/naver/playlist/PlayListTest.java
@@ -6,7 +6,6 @@ import com.naver.playlist.domain.entity.member.Member;
 import com.naver.playlist.domain.entity.playlist.PlayList;
 import com.naver.playlist.domain.redis.RedisHashService;
 import com.naver.playlist.domain.repository.MemberRepository;
-import com.naver.playlist.domain.repository.PlayListRepository;
 import com.naver.playlist.domain.service.PlayListService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;

--- a/src/test/java/com/naver/playlist/PlayListTest.java
+++ b/src/test/java/com/naver/playlist/PlayListTest.java
@@ -6,6 +6,7 @@ import com.naver.playlist.domain.entity.member.Member;
 import com.naver.playlist.domain.entity.playlist.PlayList;
 import com.naver.playlist.domain.redis.RedisHashService;
 import com.naver.playlist.domain.repository.MemberRepository;
+import com.naver.playlist.domain.repository.PlayListRepository;
 import com.naver.playlist.domain.service.PlayListService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] PlayListItem의 순서 구조를 Gap-based numbering 방식으로 선택
- [x] fetch join + IN 쿼리를 통해 쿼리 성능 최적화 
- [x] 벌크 업데이트 실패시, 전체 순서 리오더링
- [x] 전체 순서 리오더링시 데이터 조회에서 오는 메모리 문제해결을 위해 DTO Projection 도입 

## 고민과 해결과정

[Gap-based-numbering 도입 이유 문서화](https://jseungmin.notion.site/Gap-based-numbering-1f1e2fd91ae28026be54f19c9c00b704?pvs=4)
[이중연결리스트 VS Gap-based-numbering 성능테스트
](https://jseungmin.notion.site/1f9e2fd91ae2806d85cde86dc9e44190?pvs=4)
### 1️⃣ Gap-based numbering 방식 도입
PlayListItem에는 순서 정보를 표시해야 한다.
가장 쉬운 방식은 0,1,2,3,4,5 이런식으로 부여하는것이다.
하지만 이는 중간에 한 데이터의 순서를 바꾸면 뒤의 전체 데이터 순서가 바뀌게 된다.
따라서 최악의 경우 N개에 대한 업데이트 쿼리가 날라간다.

처음에는 이중연결 리스트 자료구조를 선택했지만 이 자료구조의 가장 큰 문제는 페이징이다.
이중 연결 리스트를 가지려면 이전 노드와 앞 노드에 대한 Id 정보를 추가로 필드로 가져야한다.
따라서 페이징을 구현할때 모든 데이터를 어플리케이션으로 불러온 후 커서를 기반으로 자른다.
이는 커서기반 페이지 네이션의 장점을 활용하지 못하고 메모리 로드되는 비용이커지므로 좋지 않다.

Gap-based numbering 방식은 10000, 20000, 30000 이런식으로 오더를 주는 것이다.
이는 만약 30000의 오더를 가진 데이터가 10000과 20000사이로 오게 된다면
이 둘의 평균값인 15000으로 오는 방식이다.
이를 통해서 하나의 데이터만 업데이트해도 되는 것이다.

### 2️⃣ Gap-based numbering 간격은 얼마가 좋을까?
리오더링의 성능은 좋지 않다. 모든 데이터에 대해 순서를 업데이트해야하기 때문이다.
기본적으로 현재 순서는 position이라는 필드로 Long타입을 가지고 있다.
또한 플레이리스트당 최대 1000개의 노래를 가질 수 있다는 점을 고려했을때 GAP을 Long의 최댓값 // 1000 과 근사한 수치로 가지면 된다.
```java
9214157878975800L
```
위의 값을 Gap으로 설정한다. 즉, 첫 순서의 값이 9214157878975800L, 두번째 순서의 값이 9214157878975800L * 2이다.

### 3️⃣ 배치 업데이트와 인덱스 설계
PlayListItem의 자료구조를 보면 position에 대해 인덱스를 가지게된다.
```java
@Entity
@Getter
@Setter(AccessLevel.NONE)
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@Table(
        uniqueConstraints = {
                @UniqueConstraint(
                        name = "uk_playlist_music",
                        columnNames = { "playListId", "musicId" }
                ),
                @UniqueConstraint(
                        name = "uk_playlist_position",
                        columnNames = { "playListId", "position" }
                )
        }
)
public class PlayListItem extends BaseEntity {

    @Id @SnowflakeId
    @GeneratedValue
    @Column(name = "playListItemId")
    private Long id;

    @Column(nullable = false)
    @Comment("정렬용 숫자 값으로 같은 플레이리스트 내에서 유일해야 한다")
    private Long position;

    @JsonIgnore
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "playListId")
    private PlayList playList;

    @JsonIgnore
    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "musicId")
    private Music music;
}
```
사실 인덱스를 수정가능하게 하는 것은 좋은 설계는 아니다.
그 이유는 인덱스 수정 시 페이지 병합과 분할이 같이 발생할 수 있다.
따라서 최소한의 배치 처리를 한다.
다만 추후 캐시를 통해 여러 요청을 모아 벌크 업데이트를 진행하여 추가 최적화를 진행할 수 있다.
또한 최대 1000개의 경우 row수가 많은 것은 아니기에, 성능테스트를 기반으로 인덱스를 제거하는 것도 하나의 방안이다.

### 4️⃣ DTO 프로젝션을 통한 메모리 효율 극대화
벌크 업데이트 실패시, 즉 복합키로인해 실패했을때 서버단에서 리오더링이 필요하다.
즉 순서를 처음부터 다시 정리해줘야 한다.
```java
private PlayListReOrderResponse bulkUpdate(
        List<ReorderPlayListItemsRequest> dto,
        Long playListId
) {
    try {
        jdbcBulkRepository.bulkUpdatePosition(dto);
        return new PlayListReOrderResponse(true, dto);
    } catch (DuplicateKeyException ex) {
        List<ReorderPlayListItemsRequest> reorderList = reorderingPositions(playListId);
        jdbcBulkRepository.bulkUpdatePosition(reorderList);
        return new PlayListReOrderResponse(false, reorderList);
    }
}

private List<ReorderPlayListItemsRequest> reorderingPositions(Long playListId) {
    List<PlayListItemProjection> playListItemAll =
            playListItemRepository.findPlayListItemAll(playListId);

    List<ReorderPlayListItemsRequest> reorderList = new ArrayList<>(playListItemAll.size());
    long position = GAP;

    for (PlayListItemProjection p : playListItemAll) {
        reorderList.add(new ReorderPlayListItemsRequest(p.getPlayListItemId(), position));
        position += GAP;
    }
    return reorderList;
}
```
하지만 findPlayListItemAll 과정에서 최대 1000개의 데이터가 로드될 수 있다. 
한두번의 요청에서는 괜찮겠지만 대규모 요청에서는 메모리 사용량이 급증할 수 있다.
따라서 DTO 프로젝션을 원하는 데이터만 로드하여 메모리 효율을 높인다.