### PR TITLE
[FEAT] 플레이리스트에 노래 추가 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
 	//Redis 라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation("org.redisson:redisson-spring-boot-starter:3.46.0")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
@@ -10,5 +10,6 @@ public class EntityConstants {
     public static final int MAX_PLAY_LIST_TITLE = 40;
     public static final int MAX_PLAY_LIST_DESCRIPTION = 200;
     public static final int MAX_PLAY_LIST_COUNT= 1000;
+    public static final int MAX_MUSIC_TITLE= 100;
     public static final long GAP = 9214157878975800L;
 }

--- a/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
@@ -9,5 +9,6 @@ public class EntityConstants {
     /*PLAY LIST*/
     public static final int MAX_PLAY_LIST_TITLE = 40;
     public static final int MAX_PLAY_LIST_DESCRIPTION = 200;
+    public static final int MAX_PLAY_LIST_COUNT= 1000;
     public static final long GAP = 9214157878975800L;
 }

--- a/src/main/java/com/naver/playlist/domain/constant/RedisConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/RedisConstants.java
@@ -2,7 +2,12 @@ package com.naver.playlist.domain.constant;
 
 public class RedisConstants {
 
+    /*KEY*/
     public static final String PLAY_LIST_HASH_NAME = "playlist:create";
+    public static final String LOCK_KEY = "playlist:lock:";
 
+    /*TIME OUT*/
     public static final int DUPLICATION_TIME_OUT_DAY = 1;
+    public static final int LOCK_NO_WAIT = 0;
+    public static final int LOCK_MAX_TIME = 2;
 }

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/req/CreatePlayListItemRequest.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/req/CreatePlayListItemRequest.java
@@ -1,12 +1,11 @@
 package com.naver.playlist.domain.dto.playlist.req;
 
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class CreatePlayListItemRequest {
+    private Long musicId;
 }

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/req/PlayListItemProjection.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/req/PlayListItemProjection.java
@@ -1,12 +1,5 @@
 package com.naver.playlist.domain.dto.playlist.req;
 
-import lombok.*;
-
-@Getter
-@Setter(AccessLevel.NONE)
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
-public class PlayListItemProjection {
-
-    private Long playListItemId;
+public interface PlayListItemProjection {
+    Long getPlayListItemId();
 }

--- a/src/main/java/com/naver/playlist/domain/dto/projection/PlayListStatProjection.java
+++ b/src/main/java/com/naver/playlist/domain/dto/projection/PlayListStatProjection.java
@@ -1,0 +1,9 @@
+package com.naver.playlist.domain.dto.projection;
+
+import com.naver.playlist.domain.entity.playlist.PlayList;
+
+public interface PlayListStatProjection {
+    PlayList getPlayList();
+    Long getCount();
+    Long getLastOrder();
+}

--- a/src/main/java/com/naver/playlist/domain/entity/music/Music.java
+++ b/src/main/java/com/naver/playlist/domain/entity/music/Music.java
@@ -13,6 +13,8 @@ import lombok.Setter;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.naver.playlist.domain.constant.EntityConstants.MAX_MUSIC_TITLE;
+
 @Entity
 @Getter
 @Setter(AccessLevel.NONE)
@@ -24,7 +26,14 @@ public class Music extends BaseEntity {
     @Column(name = "musicId")
     private Long id;
 
+    @Column(length = MAX_MUSIC_TITLE)
+    private String title;
+
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "music")
     private List<PlayListItem> playListItemList = new ArrayList<>();
+
+    public Music(String title) {
+        this.title = title;
+    }
 }

--- a/src/main/java/com/naver/playlist/domain/entity/playlist/PlayList.java
+++ b/src/main/java/com/naver/playlist/domain/entity/playlist/PlayList.java
@@ -41,4 +41,11 @@ public class PlayList extends BaseEntity {
     @JsonIgnore
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "playList")
     private List<PlayListItem> playListItemList = new ArrayList<>();
+
+    public PlayList(String title, String description, Member member) {
+        this.title = title;
+        this.description = description;
+        this.member = member;
+        member.getPlayListList().add(this);
+    }
 }

--- a/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
+++ b/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
@@ -53,4 +53,10 @@ public class PlayListItem extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "musicId")
     private Music music;
+
+    public PlayListItem(Long position, PlayList playList, Music music) {
+        this.position = position;
+        this.playList = playList;
+        this.music = music;
+    }
 }

--- a/src/main/java/com/naver/playlist/domain/repository/MusicRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/MusicRepository.java
@@ -1,0 +1,9 @@
+package com.naver.playlist.domain.repository;
+
+import com.naver.playlist.domain.entity.music.Music;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MusicRepository extends JpaRepository<Music, Long> {
+}

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
@@ -17,8 +17,12 @@ public interface PlayListItemRepository extends JpaRepository<PlayListItem, Long
             "where pli.id in :ids")
     List<PlayListItem> findPlayListItemForUpdate(List<Long> ids);
 
-    @Query("select pli.id as playListItemId, pli.position as position from PlayListItem pli " +
-            "where pli.playList.id = :playListId " +
-            "order by pli.position")
+    @Query("""
+           select pli.id       as playListItemId,
+                  pli.position as position
+           from   PlayListItem pli
+           where  pli.playList.id = :playListId
+           order  by pli.position
+    """)
     List<PlayListItemProjection> findPlayListItemAll(Long playListId);
 }

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListRepository.java
@@ -1,9 +1,28 @@
 package com.naver.playlist.domain.repository;
 
+import com.naver.playlist.domain.dto.projection.PlayListStatProjection;
 import com.naver.playlist.domain.entity.playlist.PlayList;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PlayListRepository extends JpaRepository<PlayList, Long> {
+
+    @Query("""
+            select  pl                            as playList,
+                    count(pi)                     as count,
+                    coalesce(max(pi.position), 0) as lastOrder
+            from    PlayList pl
+            left join PlayListItem pi on pi.playList = pl
+            where   pl.id         = :playListId
+              and   pl.member.id  = :memberId
+            group by pl
+    """)
+    Optional<PlayListStatProjection> findPlayListWithStat(
+            Long playListId,
+            Long memberId
+    );
 }

--- a/src/main/java/com/naver/playlist/domain/service/MusicService.java
+++ b/src/main/java/com/naver/playlist/domain/service/MusicService.java
@@ -1,0 +1,36 @@
+package com.naver.playlist.domain.service;
+
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.repository.MusicRepository;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.naver.playlist.web.exception.ExceptionType.MUSIC_NOT_EXIST;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MusicService {
+
+    private final MusicRepository musicRepository;
+
+    public Music getMusic(
+            Long musicId
+    ) {
+        Optional<Music> optional =
+                musicRepository.findById(musicId);
+
+        if (optional.isEmpty()) {
+            throw new PlayListException(
+                    MUSIC_NOT_EXIST.getCode(),
+                    MUSIC_NOT_EXIST.getErrorMessage()
+            );
+        }
+
+        return optional.get();
+    }
+}

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -101,7 +101,7 @@ public class PlayListController {
             HttpServletRequest request,
             @PathVariable Long playlistId,
             @RequestBody CreatePlayListItemRequest dto
-    ) {
+    ) throws InterruptedException {
         Long memberId = validateMemberId(request);
 
         Music music = musicService.getMusic(

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -5,6 +5,8 @@ import com.naver.playlist.domain.dto.playlist.req.DeletePlayListItemRequest;
 import com.naver.playlist.domain.dto.playlist.req.PlayListCreateRequest;
 import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.service.MusicService;
 import com.naver.playlist.domain.service.PlayListItemService;
 import com.naver.playlist.domain.service.PlayListService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,20 +23,25 @@ import static com.naver.playlist.domain.validator.PlayListValidator.validatePlay
 @RequiredArgsConstructor
 public class PlayListController {
 
+    private final MusicService musicService;
     private final PlayListService playListService;
     private final PlayListItemService playListItemService;
 
     /*
-     * 플레이리스트 생성
-     * 플레이리스트 생성은 대규모로 이어지고 있음을 가정한다.
-     * 레디스와 벌크 인서트를 통해 플레이리스트 생성 성능을 최적화한다.
-     * 1. DTO 유효성 검사
+     * 플레이리스트 생성 API
+     *
+     * 요구사항:
+     * - 플레이리스트 생성 요청이 대규모로 이루어지는 상황을 가정한다.
+     * - Redis 캐싱 및 벌크 인서트를 통해 플레이리스트 생성 성능을 최적화한다.
+     *
+     * 프로세스:
+     * 1. 요청 DTO의 유효성 검사
      * 2. 사용자 인증 정보 조회
-     * 3. 플레이리스트 생성 정보를 인증정보와 함께 레디스에 스냅샷(백업) 생성
-     * 4. 사용자에게 미리 응답
-     * 5. 500ms 주기에 맞춰서 배치 삽입
-     * 6. 만약 배치 삽입할 개수가 50개를 넘는다면 미리 벌크 인서트 및 성공 시 삭제
-     * */
+     * 3. 플레이리스트 생성 데이터를 사용자 인증 정보와 함께 Redis에 스냅샷 형태로 임시 저장(백업)
+     * 4. 즉시 사용자에게 성공 응답
+     * 5. 500ms 간격으로 주기적 배치(batch) 삽입 수행
+     * 6. 배치 삽입 대기 건수가 50개 이상이면 즉시 벌크 인서트를 수행하고, 성공적으로 처리된 항목은 Redis에서 삭제
+     */
     @PostMapping
     public PlayListCreateDto create(
             HttpServletRequest request,
@@ -70,13 +77,42 @@ public class PlayListController {
         return;
     }
 
+    /*
+     * 플레이리스트 노래 추가 API
+     *
+     * 요구사항:
+     * - 플레이리스트에 노래를 추가하는 기능은 해당 플레이리스트의 작성자만 가능하다.
+     * - 플레이리스트의 최대 노래 수는 1000개로 제한된다.
+     * - 애플리케이션 레벨에서 1차로 개수 제한을 하고, DB 트리거를 통해 2차적인 추가 제한을 실시한다.
+     *
+     * 프로세스:
+     * 1. 요청 DTO의 유효성 검사
+     * 2. 사용자 인증 정보 조회
+     * 3. 사용자 권한(작성자 여부) 검증
+     * 4. 음악 존재 여부 체크
+     * 4. 단일 쿼리 최적화
+     *    - 플레이리스트 자체 조회
+     *    - 플레이리스트 내 노래 개수 제한 확인
+     *    - 플레이리스트 내 가장 큰 Order 조회
+     * 5. 분산락을 활용해 동시 접근 시 데이터 일관성 유지
+     */
     @PostMapping("/{playlistId}/items")
     public void addItemToPlaylist(
             HttpServletRequest request,
             @PathVariable Long playlistId,
             @RequestBody CreatePlayListItemRequest dto
     ) {
-        return;
+        Long memberId = validateMemberId(request);
+
+        Music music = musicService.getMusic(
+                dto.getMusicId()
+        );
+
+        playListItemService.create(
+                playlistId,
+                memberId,
+                music
+        );
     }
 
     @DeleteMapping("/{playlistId}/items")
@@ -89,23 +125,25 @@ public class PlayListController {
     }
 
     /*
-     * 플레이리스트 순서 변경
-     * 플레이리스트 순서 변경은 오직 플레이리스트 작성자만 가능하다.
-     * Gap-based numbering 방식을 통해 순서를 구성한다.
-     * 순서 변경의 경우 클라이언트에서 체크 후 전송되어짐을 가정한다.
-     * 즉, 노래의 순서가 변경되었을 경우, 이 변환된 순서 값을 클라이언트에서 감지하여 서버로 전송한다.
-     * 전체 리오더링도 여기에 포함된다.
-     * 서버는 배치 업데이트를 진행한다.
+     * 플레이리스트 노래 순서 변경 API
+     *
+     * 요구사항:
+     * - 플레이리스트의 순서 변경은 해당 플레이리스트의 작성자만 가능하다.
+     * - 노래 순서는 Gap-based numbering 방식을 사용하여 관리한다.
+     * - 클라이언트에서 노래 순서 변경을 감지하여, 변경된 순서 데이터를 서버로 전송한다.
+     * - 전체 플레이리스트 리오더링 역시 이 방식으로 처리된다.
+     *
+     * 프로세스:
      * 1. DTO 유효성 검사
      * 2. 사용자 인증 정보 조회
-     * 3. 업데이트 할 데이터 조회 - 이떄 쿼리 최적화를 통해 IN 쿼리로 진행한다.
-     *     - playListItem과 playList가 올바르게 매핑되어 있는지 확인
-     *     - playList와 회원이 올바르게 매핑되어 있는지 확인
-     * 4. 데이터 배치 처리
-     * 5. 만약 장애 발생시 리오더링을 진행 후 클라이언트에 알림
-     * 6. 리오더링 과정에서 DTO 프로젝션을 통해서 성능 최적화
-     * 7. 클라이언트는 재시도 요청 보냄
-     * */
+     * 3. 업데이트 대상 데이터 조회 (IN 쿼리로 최적화 진행)
+     *    - playListItem과 playList의 매핑 유효성 검사
+     *    - playList와 회원(member)의 매핑 유효성 검사
+     * 4. 변경된 순서 데이터를 배치(batch) 처리로 업데이트
+     * 5. 장애 발생 시 재정렬(리오더링)을 서버에서 수행하고 클라이언트에 알림
+     * 6. 재정렬(리오더링)을 위한 데이터 조회 시 DTO 프로젝션을 활용해 성능 최적화
+     * 7. 클라이언트는 실패 응답을 받으면 재시도 요청 수행
+     */
     @PatchMapping("/{playlistId}/items/order")
     public void reorderItems(
             HttpServletRequest request,

--- a/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
+++ b/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
@@ -14,6 +14,7 @@ public enum ExceptionType {
 
     /* INFRA Exception */
     LUA_SCRIPT_RETURN_INVALID( 91000, "루아 스크립트 반환 정보가 잘못되었습니다."),
+    REDIS_LOCK_INTERRUPT( 91001, "인터럽트가 발생했습니다."),
 
     /* MEMBER Exception */
     MEMBER_AUTH_ID_INVALID( 10000, "회원 인증정보가 적절하지 않습니다."),
@@ -24,6 +25,7 @@ public enum ExceptionType {
     PLAY_LIST_ITEM_NOT_EXIST( 20002, "플레이리스트 노래가 존재하지 않습니다."),
     PLAY_LIST_NOT_MATCH_ITEM( 20003, "같은 플레이리스트의 노래만 업데이트 해주세요."),
     PLAY_LIST_EXCEED_LIMIT( 20004, "플레이리스트는 최대 1000개까지 생성할 수 있습니다."),
+    PLAY_LIST_NOT_CONCURRENCY( 20005, "플레이리스트는 동시에 수정할 수 없어요."),
 
     MUSIC_NOT_EXIST( 21000, "음악이 존재하지 않습니다."),
 

--- a/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
+++ b/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
@@ -23,6 +23,9 @@ public enum ExceptionType {
     PLAY_LIST_AUTH_INVALID( 20001, "플레이리스트 접근 권한이 없습니다."),
     PLAY_LIST_ITEM_NOT_EXIST( 20002, "플레이리스트 노래가 존재하지 않습니다."),
     PLAY_LIST_NOT_MATCH_ITEM( 20003, "같은 플레이리스트의 노래만 업데이트 해주세요."),
+    PLAY_LIST_EXCEED_LIMIT( 20004, "플레이리스트는 최대 1000개까지 생성할 수 있습니다."),
+
+    MUSIC_NOT_EXIST( 21000, "음악이 존재하지 않습니다."),
 
 
     /* DTO Exception */

--- a/src/test/java/com/naver/playlist/PlayListItemTest.java
+++ b/src/test/java/com/naver/playlist/PlayListItemTest.java
@@ -1,0 +1,106 @@
+package com.naver.playlist;
+
+import com.naver.playlist.domain.entity.member.Member;
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import com.naver.playlist.domain.redis.RedisHashService;
+import com.naver.playlist.domain.repository.MemberRepository;
+import com.naver.playlist.domain.repository.MusicRepository;
+import com.naver.playlist.domain.repository.PlayListRepository;
+import com.naver.playlist.domain.service.PlayListItemService;
+import com.naver.playlist.domain.service.PlayListService;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.naver.playlist.web.exception.ExceptionType.PLAY_LIST_EXCEED_LIMIT;
+import static com.naver.playlist.web.exception.ExceptionType.PLAY_LIST_NOT_EXIST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest()
+public class PlayListItemTest extends ServiceTest {
+
+    @Autowired
+    private PlayListRepository playListRepository;
+
+    @Autowired
+    private PlayListItemService playListItemService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MusicRepository musicRepository;
+
+    private Member 회원1;
+    private Member 회원2;
+    private PlayList 플레이리스트;
+    private List<Music> 음악리스트 = new ArrayList<>();
+
+    @BeforeEach
+    public void setUp() {
+        회원1 = memberRepository.save(new Member("이름"));
+        회원2 = memberRepository.save(new Member("이름"));
+        플레이리스트 = playListRepository.save(new PlayList("제목", "설명", 회원1));
+        for (int i = 0; i < 1001; i++) {
+            음악리스트.add(musicRepository.save(new Music("음악" + i)));
+        }
+        flushAndClear();
+    }
+
+    @Test
+    @DisplayName("1. 플레이리스트에 노래 삽입 - 플레이리스트에 노래를 1000개까지 삽입할 수 있다.")
+    void 플레이리스트에_노래_삽입() {
+        //given when then
+        for (int i = 0; i < 1000; i++) {
+            Music 음악 = 음악리스트.get(i);
+            assertDoesNotThrow(() -> playListItemService.create(플레이리스트.getId(), 회원1.getId(), 음악));
+        }
+    }
+
+    @Test
+    @DisplayName("1. 플레이리스트에 노래 삽입 - 엣지 케이스 - 플레이리스트가 없으면 노래를 삽입할 수 없다.")
+    void 플레이리스트가_없으면_노래를_만들수없다() {
+        //given when then
+        PlayListException 예외 = assertThrows(PlayListException.class, () -> {
+            Music 음악 = 음악리스트.get(0);
+            playListItemService.create(-1L, 회원1.getId(), 음악);
+        });
+
+        assertEquals(PLAY_LIST_NOT_EXIST.getCode(), 예외.getCode());
+        assertEquals(PLAY_LIST_NOT_EXIST.getErrorMessage(), 예외.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("1. 플레이리스트에 노래 삽입 - 엣지 케이스 - 플레이리스트에는 최대 1000개까지 노래를 삽입할 수 있다.")
+    void 플레이리스트에는_최대_1000개까지_노래를_만들수없다() {
+        //given
+        for (int i = 0; i < 1000; i++) {
+            Music 음악 = 음악리스트.get(i);
+            playListItemService.create(플레이리스트.getId(), 회원1.getId(), 음악);
+        }
+
+        flushAndClear();
+
+        //when then
+        PlayListException 예외 = assertThrows(PlayListException.class, () -> {
+            Music 음악 = 음악리스트.get(1000);
+            playListItemService.create(플레이리스트.getId(), 회원1.getId(), 음악);
+        });
+
+        assertEquals(PLAY_LIST_EXCEED_LIMIT.getCode(), 예외.getCode());
+        assertEquals(PLAY_LIST_EXCEED_LIMIT.getErrorMessage(), 예외.getErrorMessage());
+    }
+}

--- a/src/test/java/com/naver/playlist/ServiceTest.java
+++ b/src/test/java/com/naver/playlist/ServiceTest.java
@@ -2,9 +2,7 @@ package com.naver.playlist;
 
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.connection.RedisServerCommands;

--- a/src/test/resources/sql/cleanup_test_data.sql
+++ b/src/test/resources/sql/cleanup_test_data.sql
@@ -1,0 +1,9 @@
+
+SET FOREIGN_KEY_CHECKS = 0;   -- FK 잠시 해제
+
+TRUNCATE TABLE play_list_item;  -- 가장 먼저 (자식 테이블)
+TRUNCATE TABLE play_list;       -- 부모
+TRUNCATE TABLE music;           -- FK 대상(자식 없음)
+TRUNCATE TABLE member;          -- 최상위
+
+SET FOREIGN_KEY_CHECKS = 1;   -- FK 재활성화


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 플레이리스트에 노래 추가 API
- [x] 분산락을 통한 동시성 제어
- [x] 쿼리 튜닝을 통해 3개의 쿼리를 1개로 최적화

## 고민과 해결과정

### 1️⃣ 왜 분산락을 사용할까?
[문서화](https://jseungmin.notion.site/1f3e2fd91ae28011bc48ccea953c5223?pvs=4)

단일 데이터베이스 환경에서는 트리거 방식이 간단하고 별도의 락을 사용하지 않아 유리할 수 있다.
또한 운영가시성 측면에서도 이미 애플리케이션 로직에 제한 사항이 명시되어 있어 큰 문제가 되지 않는다.
그러나 여러 데이터베이스를 운영하거나 로직 변경이 빈번한 환경에서는 DB 단에서 관리가 어렵다는 단점이 있다.
반면 분산락 방식은 애플리케이션에서 집중 관리가 가능해, 데이터베이스별로 개별 작업을 할 필요가 없어 관리적 부담이 적고 확장성이 뛰어나다.
결론적으로 관리 효율성과 확장성을 고려하여 분산락 방식을 선택하였다.

### 2️⃣ 쿼리 튜닝이 얼마의 성능 차이를 보일까?
[문서화](https://jseungmin.notion.site/3-1-1f3e2fd91ae280508cbcf974c44d8dd0?pvs=4)

플레이리스트에 음악을 직접 저장하면 중복된 곡 관리 문제가 발생하기 때문에, 이를 해결하기 위해 중간 객체인 '플레이리스트 아이템'을 사용하여 N:M 관계를 해소한다. 
기존 방식으로는 음악 존재 여부, 플레이리스트 유효성, 아이템 개수 제한, 마지막 순서값 조회, 플레이리스트 아이템 저장 등 총 5회의 쿼리가 필요했다.
하지만 이를 최적화하기 위해 플레이리스트 조회, 아이템 개수, 마지막 순서값 조회를 하나의 통합 쿼리로 구현하였다. 

```java
@Query("""
        select  pl                            as playList,
                count(pi)                     as count,
                coalesce(max(pi.position), 0) as lastOrder
        from    PlayList pl
        left join PlayListItem pi on pi.playList = pl
        where   pl.id         = :playListId
          and   pl.member.id  = :memberId
        group by pl
""")
Optional<PlayListStatProjection> findPlayListWithStat(
        Long playListId,
        Long memberId
);
```
이를 통해 성능상 효율성을 높였으며, 하나의 쿼리에서 GROUP BY와 COALESCE를 활용하여 플레이리스트 아이템이 없어도 정상적으로 결과를 반환하게 했다. 최종적으로 전체 프로세스는 기존의 3개의 쿼리를 1개로로 줄이면서 성능과 관리의 효율성을 높였다.