### PR TITLE
[FEAT] 인기 플레이리스트 캐시 조회

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/main/java/com/naver/playlist/domain/test/**
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	queryDslVersion = '5.1.0'
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -39,8 +43,16 @@ dependencies {
 	//Redis 라이브러리
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation("org.redisson:redisson-spring-boot-starter:3.46.0")
+
+	//QUERY DSL
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}:jakarta"
+	annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+sourceSets.main.java.srcDirs += "$buildDir/generated/sources/annotationProcessor/java/main"

--- a/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/EntityConstants.java
@@ -11,5 +11,6 @@ public class EntityConstants {
     public static final int MAX_PLAY_LIST_DESCRIPTION = 200;
     public static final int MAX_PLAY_LIST_COUNT= 1000;
     public static final int MAX_MUSIC_TITLE= 100;
+    public static final int MAX_PLAY_PAGE_SIZE = 20;
     public static final long GAP = 9214157878975800L;
 }

--- a/src/main/java/com/naver/playlist/domain/constant/RedisConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/RedisConstants.java
@@ -4,10 +4,16 @@ public class RedisConstants {
 
     /*KEY*/
     public static final String PLAY_LIST_HASH_NAME = "playlist:create";
+    public static final String PLAY_LIST_ITEM_KEY = "playlistItem:";
     public static final String LOCK_KEY = "playlist:lock:";
+    public static final String PLAY_LIST_ITEM_LOCK_KEY = "playlistItem:lock:";
 
     /*TIME OUT*/
     public static final int DUPLICATION_TIME_OUT_DAY = 1;
     public static final int LOCK_NO_WAIT = 0;
     public static final int LOCK_MAX_TIME = 2;
+    public static final int PLAY_LIST_ITEM_TTL = 300;
+    public static final int THRESHOLD = 100;
+    public static final int PLAY_LIST_TIME_LOCK_WAIT = 1;
+    public static final int PLAY_LIST_TIME_LOCK_MAX_TIME = 3;
 }

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListItemResponse.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListItemResponse.java
@@ -1,0 +1,20 @@
+package com.naver.playlist.domain.dto.playlist.res;
+
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import lombok.*;
+
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlayListItemResponse {
+    private Long id;
+    private Long order;
+    private String title;
+
+    public PlayListItemResponse(PlayListItem playListItem) {
+        this.id = playListItem.getId();
+        this.order = playListItem.getPosition();
+        this.title = playListItem.getMusic().getTitle();
+    }
+}

--- a/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListResponse.java
+++ b/src/main/java/com/naver/playlist/domain/dto/playlist/res/PlayListResponse.java
@@ -1,0 +1,26 @@
+package com.naver.playlist.domain.dto.playlist.res;
+
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import lombok.*;
+
+import java.util.List;
+
+import static com.naver.playlist.domain.constant.EntityConstants.MAX_PLAY_PAGE_SIZE;
+
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class PlayListResponse {
+    private List<PlayListItemResponse> playListItems;
+    private boolean hasNext;
+
+    public PlayListResponse(List<PlayListItem> dtoList) {
+        this.hasNext = dtoList.size() > MAX_PLAY_PAGE_SIZE;
+
+        this.playListItems = dtoList.stream()
+                .limit(MAX_PLAY_PAGE_SIZE)
+                .map(PlayListItemResponse::new)
+                .toList();
+    }
+}

--- a/src/main/java/com/naver/playlist/domain/dto/redis/PlayListCreateDto.java
+++ b/src/main/java/com/naver/playlist/domain/dto/redis/PlayListCreateDto.java
@@ -19,8 +19,8 @@ public class PlayListCreateDto {
     public PlayListCreateDto(
             PlayListCreateRequest dto,
             Long playlistId,
-            Long memberId)
-    {
+            Long memberId
+    ) {
         this.playlistId = playlistId;
         this.memberId = memberId;
         this.title = dto.getTitle();

--- a/src/main/java/com/naver/playlist/domain/redis/RedisHashService.java
+++ b/src/main/java/com/naver/playlist/domain/redis/RedisHashService.java
@@ -14,10 +14,8 @@ import org.springframework.stereotype.Service;
 import java.time.Duration;
 import java.util.*;
 
-import static com.naver.playlist.domain.constant.RedisConstants.DUPLICATION_TIME_OUT_DAY;
-import static com.naver.playlist.domain.constant.RedisConstants.PLAY_LIST_HASH_NAME;
-import static com.naver.playlist.domain.script.LUA_SCRIPT.EXTRACT_PLAY_LIST_LUA;
-import static com.naver.playlist.domain.script.LUA_SCRIPT.INSERT_PLAY_LIST_LUA;
+import static com.naver.playlist.domain.constant.RedisConstants.*;
+import static com.naver.playlist.domain.script.LUA_SCRIPT.*;
 import static com.naver.playlist.web.exception.ExceptionType.*;
 
 @Service

--- a/src/main/java/com/naver/playlist/domain/redis/RedisPlayListService.java
+++ b/src/main/java/com/naver/playlist/domain/redis/RedisPlayListService.java
@@ -1,0 +1,120 @@
+package com.naver.playlist.domain.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.naver.playlist.domain.dto.playlist.res.PlayListResponse;
+import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import com.naver.playlist.web.exception.CommonException;
+import com.naver.playlist.web.exception.infra.InfraException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+import static com.naver.playlist.domain.constant.RedisConstants.*;
+import static com.naver.playlist.domain.script.LUA_SCRIPT.*;
+import static com.naver.playlist.web.exception.ExceptionType.*;
+
+@Service
+@RequiredArgsConstructor
+public class RedisPlayListService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    private static final RedisScript<List> GET_PLAYLIST_SCRIPT =
+            RedisScript.of(GET_PLAY_LIST_LUA, List.class);
+
+    private static final RedisScript<List> PUT_PLAYLIST_SCRIPT =
+            RedisScript.of(PUT_PLAY_LIST_LUA, List.class);
+
+    /*
+     * 해시안에 순서 정보를 key, 데이터 자체를 value로 가지는 캐시 존재
+     * 플레이리스트 페이지 삽입 Lua 스크립트로 원자적으로 삽입하고
+     * 참조 카운팅이 없다면 초기화, 만약 TTL이 없다면 초기화
+     */
+    public void insertPlayListCache(
+            String hashKey,
+            String fieldKey,
+            PlayListResponse response
+    ) {
+        String json = convertToString(response);
+
+        redisTemplate.execute(
+                PUT_PLAYLIST_SCRIPT,
+                Collections.singletonList(hashKey),
+                fieldKey,
+                json,
+                String.valueOf(PLAY_LIST_ITEM_TTL)
+        );
+    }
+
+    /*
+     * 플레이리스트 조회를 Lua 스크립트로 원자적으로 조회하고
+     * 참조 카운팅 증가, 만약 참조카운팅이 특정 임계를 넘어서면 TTL 초기화
+     * 이를 통해 인기게시글에 대한 캐시 유지
+     */
+    public PlayListResponse getPlayList(
+            Long playListId,
+            Long cursor
+    ) {
+        String hashKey  = PLAY_LIST_ITEM_KEY + playListId;
+        String fieldKey = String.valueOf(cursor == null ? 0 : cursor);
+
+        List<Object> result = executeGetPlayListScript(hashKey, fieldKey);
+        validateLuaResult(result);
+
+        if (!String.valueOf(result.get(0)).equals("true")) {
+            return null;
+        }
+
+        return convertToJson(String.valueOf(result.get(1)));
+    }
+
+    /* Lua 스크립트를 실행하고 결과를 그대로 반환 */
+    private List<Object> executeGetPlayListScript(String hashKey, String fieldKey) {
+        @SuppressWarnings("unchecked")
+        List<Object> result = (List<Object>) redisTemplate.execute(
+                GET_PLAYLIST_SCRIPT,
+                Collections.singletonList(hashKey),
+                fieldKey,
+                String.valueOf(PLAY_LIST_ITEM_TTL),
+                String.valueOf(THRESHOLD)
+        );
+        return result;
+    }
+
+    /* Lua 결과가 유효한지 검증 */
+    private void validateLuaResult(List<Object> result) {
+        if (result == null || result.isEmpty()) {
+            throw new InfraException(
+                    LUA_SCRIPT_RETURN_INVALID.getCode(),
+                    LUA_SCRIPT_RETURN_INVALID.getErrorMessage()
+            );
+        }
+    }
+
+    private String convertToString(PlayListResponse dto) {
+        try {
+            return objectMapper.writeValueAsString(dto);
+        } catch (JsonProcessingException e) {
+            throw new CommonException(
+                    SERIALIZABLE_EXCEPTION.getCode(),
+                    SERIALIZABLE_EXCEPTION.getErrorMessage()
+            );
+        }
+    }
+
+    private PlayListResponse convertToJson(String value) {
+        try {
+            return objectMapper.readValue(value, PlayListResponse.class);
+        } catch (JsonProcessingException e) {
+            throw new CommonException(
+                    UN_SERIALIZABLE_EXCEPTION.getCode(),
+                    UN_SERIALIZABLE_EXCEPTION.getErrorMessage()
+            );
+        }
+    }
+}

--- a/src/main/java/com/naver/playlist/domain/repository/PaginationRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PaginationRepository.java
@@ -1,0 +1,43 @@
+package com.naver.playlist.domain.repository;
+
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.naver.playlist.domain.constant.EntityConstants.MAX_PLAY_PAGE_SIZE;
+import static com.naver.playlist.domain.entity.playlist.QPlayListItem.playListItem;
+
+@Repository
+@RequiredArgsConstructor
+public class PaginationRepository {
+
+	private final JPAQueryFactory query;
+
+	public List<PlayListItem> getPlayListItemByCursor(
+			Long cursor,
+			Long playListId
+	) {
+		return query.select(playListItem)
+				.from(playListItem)
+				.join(playListItem.music).fetchJoin()
+				.where(
+						getId(playListId),
+						getAfter(cursor)
+				)
+				.orderBy(playListItem.position.asc())
+				.limit(MAX_PLAY_PAGE_SIZE + 1)
+				.fetch();
+	}
+
+	private BooleanExpression getAfter(Long cursor) {
+		return cursor == null ? null : playListItem.position.gt(cursor);
+	}
+
+	private BooleanExpression getId(Long playListId) {
+		return playListId == null ? null : playListItem.playList.id.eq(playListId);
+	}
+}

--- a/src/main/java/com/naver/playlist/domain/script/LUA_SCRIPT.java
+++ b/src/main/java/com/naver/playlist/domain/script/LUA_SCRIPT.java
@@ -61,4 +61,62 @@ public class LUA_SCRIPT {
         local snapshotData = redis.call('HGETALL', snapshotKey)
         return { 'true', snapshotKey, snapshotData }
         """;
+
+    public static final String GET_PLAY_LIST_LUA = """
+        -- KEYS[1] : 원본 해시 키
+        -- ARGV[1] : 필드 키
+        -- ARGV[2] : 스냅샷 TTL
+        -- ARGV[3] : 임계치(THRESHOLD)
+        
+        local hashKey   = KEYS[1]
+        local fieldKey  = ARGV[1]
+        local ttl       = tonumber(ARGV[2])
+        local threshold = tonumber(ARGV[3])
+        
+        -- 1) 페이지 데이터 조회
+        local data = redis.call('HGET', hashKey, fieldKey)
+        if not data then
+            return { 'false' }
+        end
+        
+        -- 2) 참조 카운팅 증가
+        local cnt = redis.call('HINCRBY', hashKey, 'cnt', 1)
+        
+        -- 3) 임계치 도달 시 TTL 연장 & 참조 카운팅 초기화
+        if cnt >= threshold then
+            redis.call('HSET', hashKey, 'cnt', 0)
+            redis.call('EXPIRE', hashKey, ttl)
+        end
+        
+        -- 4) HIT 결과 반환
+        return { 'true', data }
+       """;
+
+    public static final String PUT_PLAY_LIST_LUA = """
+        -- KEYS[1] : 원본 해시 키
+        -- ARGV[1] : 필드 키
+        -- ARGV[2] : JSON
+        -- ARGV[3] : 스냅샷 TTL
+        
+        local hashKey  = KEYS[1]
+        local fieldKey = ARGV[1]
+        local data     = ARGV[2]
+        local ttl      = tonumber(ARGV[3])
+        
+        -- 1) 새 페이지 저장
+        redis.call('HSET', hashKey, fieldKey, data)
+        
+        -- 2) 참조 카운팅 없으면 0으로 초기화
+        if redis.call('HEXISTS', hashKey, 'cnt') == 0 then
+            redis.call('HSET', hashKey, 'cnt', 0)
+        end
+        
+        -- 3) TTL이 없으면(== -1) 설정
+        if redis.call('TTL', hashKey) < 0 then
+           redis.call('EXPIRE', hashKey, ttl)
+        end
+        
+        -- 4) 결과 반환
+        return { 'OK' }
+        """;
 }

--- a/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
@@ -11,7 +11,6 @@ import com.naver.playlist.domain.repository.JdbcBulkRepository;
 import com.naver.playlist.domain.repository.PlayListItemRepository;
 import com.naver.playlist.domain.repository.PlayListRepository;
 import com.naver.playlist.web.exception.entity.PlayListException;
-import com.naver.playlist.web.exception.infra.InfraException;
 import lombok.RequiredArgsConstructor;
 import org.redisson.api.RLock;
 import org.redisson.api.RedissonClient;

--- a/src/main/java/com/naver/playlist/domain/service/PlayListService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListService.java
@@ -7,12 +7,18 @@ import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
 import com.naver.playlist.domain.entity.playlist.PlayListItem;
 import com.naver.playlist.domain.generator.IDGenerator;
 import com.naver.playlist.domain.redis.RedisHashService;
+import com.naver.playlist.domain.redis.RedisPlayListService;
 import com.naver.playlist.domain.repository.PaginationRepository;
 import lombok.RequiredArgsConstructor;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.naver.playlist.domain.constant.RedisConstants.*;
 
 @Service
 @RequiredArgsConstructor
@@ -20,9 +26,11 @@ import java.util.List;
 public class PlayListService {
 
     private final RedisHashService redisHashService;
+    private final RedisPlayListService redisPlayListService;
     private final PlayListAsyncService asyncService;
     private final PaginationRepository paginationRepository;
     private final IDGenerator idGenerator;
+    private final RedissonClient redisson;
 
     public PlayListCreateDto create(
             PlayListCreateRequest request,
@@ -48,12 +56,69 @@ public class PlayListService {
     public PlayListResponse get(
             Long playListId,
             Long cursor
-    ) {
-        // 1️⃣ 페이지네이션을 통해 플레이리스트 아이템 조회
-        List<PlayListItem> dtoList = paginationRepository.getPlayListItemByCursor(
-                cursor,
-                playListId
+    ) throws InterruptedException {
+
+        // 1️⃣LUA를 캐시 통한 조회
+        PlayListResponse cached = getFromCache(playListId, cursor);
+        if (cached != null) {
+            return cached;
+        }
+
+        // 2️⃣캐시 미스시 분산락을 통한 캐시 스템피드 제어
+        String lockKey = PLAY_LIST_ITEM_LOCK_KEY + playListId + ":" + cursor;
+        RLock lock = redisson.getLock(lockKey);
+        boolean acquired = false;
+
+        try {
+            acquired = getRock(lock);
+
+            // 3️⃣락 획득 실패 시 캐시 재조회
+            if (!acquired) {
+                return getFromCache(playListId, cursor);
+            }
+
+            // 4️⃣다시 한번 재조회, 락을 획득한 사이 업데이트 되었을 수 있다.
+            cached = getFromCache(playListId, cursor);
+            if (cached != null) {
+                return cached;
+            }
+
+            // 5️⃣페이지네이션을 통해 플레이리스트 아이템 조회
+            List<PlayListItem> dtoList =
+                    paginationRepository.getPlayListItemByCursor(cursor, playListId);
+
+            // 6️⃣플레이리스트 캐시 업데이트
+            PlayListResponse response = new PlayListResponse(dtoList);
+            redisPlayListService.insertPlayListCache(
+                    PLAY_LIST_ITEM_KEY + playListId,
+                    String.valueOf(cursor == null ? 0 : cursor),
+                    response
+            );
+
+            return response;
+        } finally {
+            releaseLock(lock, acquired);
+        }
+    }
+
+    private PlayListResponse getFromCache(Long playListId, Long cursor) {
+        return redisPlayListService.getPlayList(
+                playListId,
+                cursor
         );
-        return new PlayListResponse(dtoList);
+    }
+
+    private boolean getRock(RLock lock) throws InterruptedException {
+        return lock.tryLock(
+                PLAY_LIST_TIME_LOCK_WAIT,
+                PLAY_LIST_TIME_LOCK_MAX_TIME,
+                TimeUnit.SECONDS
+        );
+    }
+
+    private void releaseLock(RLock lock, boolean acquired) {
+        if (acquired && lock.isHeldByCurrentThread()) {
+            lock.unlock();
+        }
     }
 }

--- a/src/main/java/com/naver/playlist/domain/service/PlayListService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListService.java
@@ -2,12 +2,17 @@ package com.naver.playlist.domain.service;
 
 import com.naver.playlist.domain.dto.playlist.req.PlayListCreateRequest;
 import com.naver.playlist.domain.dto.playlist.res.PlayListCreateResponse;
+import com.naver.playlist.domain.dto.playlist.res.PlayListResponse;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
 import com.naver.playlist.domain.generator.IDGenerator;
 import com.naver.playlist.domain.redis.RedisHashService;
+import com.naver.playlist.domain.repository.PaginationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +21,7 @@ public class PlayListService {
 
     private final RedisHashService redisHashService;
     private final PlayListAsyncService asyncService;
+    private final PaginationRepository paginationRepository;
     private final IDGenerator idGenerator;
 
     public PlayListCreateDto create(
@@ -37,5 +43,17 @@ public class PlayListService {
 
         asyncService.bulkInsertAsync(response);
         return dto;
+    }
+
+    public PlayListResponse get(
+            Long playListId,
+            Long cursor
+    ) {
+        // 1️⃣ 페이지네이션을 통해 플레이리스트 아이템 조회
+        List<PlayListItem> dtoList = paginationRepository.getPlayListItemByCursor(
+                cursor,
+                playListId
+        );
+        return new PlayListResponse(dtoList);
     }
 }

--- a/src/main/java/com/naver/playlist/web/config/QueryDSLConfig.java
+++ b/src/main/java/com/naver/playlist/web/config/QueryDSLConfig.java
@@ -1,0 +1,19 @@
+package com.naver.playlist.web.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QueryDSLConfig {
+
+	private final EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory() {
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -68,6 +68,21 @@ public class PlayListController {
         return;
     }
 
+    /*
+     * 플레이리스트 노래 조회 API
+     *
+     * 요구사항:
+     * - 플레이리스트에는 대규모 트래픽의 조회가 발생한다.
+     * - 플레이리스트에 변경 자체는 많지 않지만, 메모리 문제로 인해 오랜시간 캐시를 사용할 수 없다.
+     *
+     * 프로세스:
+     * 1. 플레이리스트 조회
+     *    - 캐시 조회, 만약 특정 참조 수를 넘어서면 TTL 초기화
+     *    - 커서기반 페이지네이션으로 조회
+     * 2. 캐시 업데이트
+     *    - 캐시에 존재하지 않을 때 캐시에 저장
+     *    - 캐시 스템피드 방지를 위해 한개의 스레드만 DB 접근
+     */
     @GetMapping("/{playlistId}/items")
     public void getItemList(
             HttpServletRequest request,

--- a/src/main/java/com/naver/playlist/web/controller/PlayListController.java
+++ b/src/main/java/com/naver/playlist/web/controller/PlayListController.java
@@ -4,6 +4,7 @@ import com.naver.playlist.domain.dto.playlist.req.CreatePlayListItemRequest;
 import com.naver.playlist.domain.dto.playlist.req.DeletePlayListItemRequest;
 import com.naver.playlist.domain.dto.playlist.req.PlayListCreateRequest;
 import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.dto.playlist.res.PlayListResponse;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
 import com.naver.playlist.domain.entity.music.Music;
 import com.naver.playlist.domain.service.MusicService;
@@ -84,12 +85,11 @@ public class PlayListController {
      *    - 캐시 스템피드 방지를 위해 한개의 스레드만 DB 접근
      */
     @GetMapping("/{playlistId}/items")
-    public void getItemList(
-            HttpServletRequest request,
+    public PlayListResponse getItemList(
             @PathVariable Long playlistId,
             @RequestParam(required = false) Long cursor
-    ) {
-        return;
+    ) throws InterruptedException {
+        return playListService.get(playlistId, cursor);
     }
 
     /*


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 커서 기반 페이지네이션 적용
- [x] 인기 플레이리스트 캐시 조회
  
## 고민과 해결과정

[문서화](https://jseungmin.notion.site/1f4e2fd91ae28009b34cc633b6e45a44?pvs=4)
[커서기반 페이지네이션 성능 테스트](https://jseungmin.notion.site/1ede2fd91ae280a89e12c1065a2a3cfd?pvs=4)

### 1️⃣ 인기 플레이리스트만 캐시에 남길 수 없을까?
대규모 트래픽이라고 한다면 인기 플레이리스트만 캐시에 남기는 것이 효율적이다.
캐시는 메모리가 중요하고 비인기 플레이리스트가 메모리에 남는 것은 비효율적이기 때문이다.
따라서 참조 카운팅을 통해 플레이리스트를 관리하다.
즉, 자주 참조가 될수록 TTL을 늘려주는 것이다.

### 2️⃣ 분산락을 통해 캐시 스템피드를 방지한다.
인기 플레이리스트일수록 요청이 많을 수 있다.
만약 여러 스레드가 동시에 접근할때 캐시에 없다면 해당 트래픽을 데이터베이스로 이어진다.
따라서 이런 문제를 해결하기 위해 분산락을 도입하여 하나의 스레드만 접근하도록 한다.

### 3️⃣ ZSET을 도입해볼까?
지금은 참조 카운트로 인기 플레이리스트를 관리한다.
다만 이 정보를 ZSET 같은 곳에서 보관하면 실시간 인기 게시글의 정보를 확인할 수 있다.
즉, 참조 카운트를 ZSET에서 관리해서 주기적으로 인기게시글 100개만 남겨줘 라고 할 수 있는 것이다.
혹은 참조 카운트 초기화하는 것이 아니라 ZSET에서 주기적으로 낮춰주는 것도 가능하다. 
다만 ZSET은 스킵 리스트 이외에 해시라는 자료구조를 추가로 가진다. 따라서 이런 부분에 대한 고려가 진행된 후 도입이 필요하다.
