### PR TITLE
[FEAT] 플레이리스트 벌크 인서트 예외 처리 및 테스트 코드 작성

### DIFF
--- a/src/main/java/com/naver/playlist/domain/constant/CommonConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/CommonConstants.java
@@ -1,0 +1,7 @@
+package com.naver.playlist.domain.constant;
+
+public class CommonConstants {
+
+    /*TIME OUT*/
+    public static final int ONE_SECOND = 1;
+}

--- a/src/main/java/com/naver/playlist/domain/constant/CommonConstants.java
+++ b/src/main/java/com/naver/playlist/domain/constant/CommonConstants.java
@@ -3,5 +3,5 @@ package com.naver.playlist.domain.constant;
 public class CommonConstants {
 
     /*TIME OUT*/
-    public static final int ONE_SECOND = 1;
+    public static final int ONE_SECOND = 1000;
 }

--- a/src/main/java/com/naver/playlist/domain/dto/projection/PlayListItemProjection.java
+++ b/src/main/java/com/naver/playlist/domain/dto/projection/PlayListItemProjection.java
@@ -1,4 +1,4 @@
-package com.naver.playlist.domain.dto.playlist.req;
+package com.naver.playlist.domain.dto.projection;
 
 public interface PlayListItemProjection {
     Long getPlayListItemId();

--- a/src/main/java/com/naver/playlist/domain/repository/JdbcBulkRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/JdbcBulkRepository.java
@@ -20,6 +20,7 @@ public class JdbcBulkRepository {
           (play_list_id, member_id, title, description, created_date, last_modified_date)
         VALUES
           (:id, :memberId, :title, :description, :createdDate, :lastModifiedDate)
+        ON DUPLICATE KEY UPDATE play_list_id = play_list_id
     """;
 
     private static final String UPDATE_SQL = """

--- a/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
+++ b/src/main/java/com/naver/playlist/domain/repository/PlayListItemRepository.java
@@ -1,6 +1,6 @@
 package com.naver.playlist.domain.repository;
 
-import com.naver.playlist.domain.dto.playlist.req.PlayListItemProjection;
+import com.naver.playlist.domain.dto.projection.PlayListItemProjection;
 import com.naver.playlist.domain.entity.playlist.PlayListItem;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/naver/playlist/domain/service/PlayListAsyncService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListAsyncService.java
@@ -1,14 +1,22 @@
 package com.naver.playlist.domain.service;
 
 import com.naver.playlist.domain.dto.playlist.res.PlayListCreateResponse;
+import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
 import com.naver.playlist.domain.redis.RedisHashService;
 import com.naver.playlist.domain.repository.JdbcBulkRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.naver.playlist.domain.constant.CommonConstants.ONE_SECOND;
 import static com.naver.playlist.domain.constant.RedisConstants.PLAY_LIST_HASH_NAME;
 
 @Service
@@ -17,15 +25,20 @@ public class PlayListAsyncService {
 
     private final JdbcBulkRepository bulkRepository;
     private final RedisHashService redisHashService;
+    private final Map<String, List<PlayListCreateDto>> fallbackCache = new ConcurrentHashMap<>();
 
     @Async
     @Transactional
     public void bulkInsertAsync(PlayListCreateResponse dto) {
-        bulkRepository.bulkInsert(dto.getPlayList());
-        redisHashService.deleteSnapshot(dto.getKey());
+        try {
+            bulkRepository.bulkInsert(dto.getPlayList());
+            redisHashService.deleteSnapshot(dto.getKey());
+        } catch (DataAccessResourceFailureException e) {
+            fallbackCache.put(dto.getKey(), dto.getPlayList());
+        }
     }
 
-    @Scheduled(fixedRate = 1000)
+    @Scheduled(fixedRate = ONE_SECOND)
     @Transactional
     public void syncPlayList() {
         PlayListCreateResponse dto = redisHashService.extractPlayList(PLAY_LIST_HASH_NAME);
@@ -34,7 +47,28 @@ public class PlayListAsyncService {
             return;
         }
 
-        bulkRepository.bulkInsert(dto.getPlayList());
-        redisHashService.deleteSnapshot(dto.getKey());
+        try {
+            bulkRepository.bulkInsert(dto.getPlayList());
+            redisHashService.deleteSnapshot(dto.getKey());
+        } catch (DataAccessResourceFailureException e) {
+            fallbackCache.put(dto.getKey(), dto.getPlayList());
+        }
+    }
+
+    @Scheduled(fixedRate = ONE_SECOND * 30)
+    @Transactional
+    public void retryFallbackCache() {
+        List<String> keyList = new ArrayList<>(fallbackCache.keySet());
+
+        for (String key : keyList) {
+            List<PlayListCreateDto> list = fallbackCache.get(key);
+            try {
+                bulkRepository.bulkInsert(list);
+                fallbackCache.remove(key);
+                redisHashService.deleteSnapshot(key);
+            } catch (DataAccessResourceFailureException e) {
+                break;
+            }
+        }
     }
 }

--- a/src/main/java/com/naver/playlist/domain/service/PlayListAsyncService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListAsyncService.java
@@ -4,6 +4,7 @@ import com.naver.playlist.domain.dto.playlist.res.PlayListCreateResponse;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
 import com.naver.playlist.domain.redis.RedisHashService;
 import com.naver.playlist.domain.repository.JdbcBulkRepository;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.scheduling.annotation.Async;
@@ -25,6 +26,8 @@ public class PlayListAsyncService {
 
     private final JdbcBulkRepository bulkRepository;
     private final RedisHashService redisHashService;
+
+    @Getter
     private final Map<String, List<PlayListCreateDto>> fallbackCache = new ConcurrentHashMap<>();
 
     @Async

--- a/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
+++ b/src/main/java/com/naver/playlist/domain/service/PlayListItemService.java
@@ -1,6 +1,6 @@
 package com.naver.playlist.domain.service;
 
-import com.naver.playlist.domain.dto.playlist.req.PlayListItemProjection;
+import com.naver.playlist.domain.dto.projection.PlayListItemProjection;
 import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
 import com.naver.playlist.domain.dto.playlist.res.PlayListReOrderResponse;
 import com.naver.playlist.domain.dto.projection.PlayListStatProjection;

--- a/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
+++ b/src/main/java/com/naver/playlist/web/exception/ExceptionType.java
@@ -16,6 +16,8 @@ public enum ExceptionType {
     LUA_SCRIPT_RETURN_INVALID( 91000, "루아 스크립트 반환 정보가 잘못되었습니다."),
     REDIS_LOCK_INTERRUPT( 91001, "인터럽트가 발생했습니다."),
 
+    DATABASE_ACCESS_EXCEPTION( 92000, "데이터베이스에 접근할 수 없습니다."),
+
     /* MEMBER Exception */
     MEMBER_AUTH_ID_INVALID( 10000, "회원 인증정보가 적절하지 않습니다."),
 

--- a/src/test/java/com/naver/playlist/PlayListAsyncServiceTest.java
+++ b/src/test/java/com/naver/playlist/PlayListAsyncServiceTest.java
@@ -1,0 +1,106 @@
+package com.naver.playlist;
+
+import com.naver.playlist.domain.dto.playlist.res.PlayListCreateResponse;
+import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
+import com.naver.playlist.domain.redis.RedisHashService;
+import com.naver.playlist.domain.repository.JdbcBulkRepository;
+import com.naver.playlist.domain.service.PlayListAsyncService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessResourceFailureException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class PlayListAsyncServiceTest {
+
+
+    @Mock JdbcBulkRepository bulkRepository;
+    @Mock RedisHashService redisHashService;
+    private PlayListAsyncService asyncService;
+
+    @BeforeEach
+    void setUp() {
+        asyncService = new PlayListAsyncService(bulkRepository, redisHashService);
+    }
+
+    @Test
+    @DisplayName("1. 데이터베이스 접근 예외 – 데이터베이스 접근 예외시 실패큐에 저장한다.")
+    void 데이터베이스_접근_예외시_실패큐에_저장한다() {
+        // given
+        List<PlayListCreateDto> list = List.of(
+                new PlayListCreateDto(1L, 1L, "", "", LocalDateTime.now().toString())
+        );
+
+        PlayListCreateResponse dto = new PlayListCreateResponse("스냅샷 키", list);
+
+        doThrow(new DataAccessResourceFailureException("데이터베이스 접근 에러"))
+                .when(bulkRepository).bulkInsert(list);
+
+        // when
+        asyncService.bulkInsertAsync(dto);
+
+        // then
+        Map<String, List<PlayListCreateDto>> 실패큐 = asyncService.getFallbackCache();
+        assertThat(실패큐.size()).isEqualTo(1);
+        assertThat(실패큐.get("스냅샷 키").size()).isEqualTo(1);
+        assertThat(실패큐.get("스냅샷 키 NULL")).isNull();
+    }
+
+    @Test
+    @DisplayName("2. 데이터베이스 재접근 예외 – 데이터베이스 재접근 예외시 여전히 실패큐에 저장한다.")
+    void 재시도_실패_시_큐_유지() {
+        // given
+        List<PlayListCreateDto> list = List.of(
+                new PlayListCreateDto(1L, 1L, "", "", LocalDateTime.now().toString())
+        );
+        PlayListCreateResponse dto = new PlayListCreateResponse("스냅샷 키", list);
+
+        doThrow(new DataAccessResourceFailureException("데이터베이스 접근 에러"))
+                .when(bulkRepository).bulkInsert(list);
+
+        asyncService.bulkInsertAsync(dto);
+
+        // when
+        asyncService.retryFallbackCache();
+
+        // then
+        Map<String, List<PlayListCreateDto>> 실패큐 = asyncService.getFallbackCache();
+        assertThat(실패큐).containsKey("스냅샷 키");
+        assertThat(실패큐.get("스냅샷 키")).hasSize(1);
+        verify(bulkRepository, times(2)).bulkInsert(list);
+        verify(redisHashService, never()).deleteSnapshot("스냅샷 키");
+    }
+
+    @Test
+    @DisplayName("3. 데이터베이스 재접근 성공 – 데이터베이스 재접근 성공시 실패큐에서 제거된다.")
+    void 재시도_성공_시_큐_삭제() {
+        // given
+        List<PlayListCreateDto> list = List.of(
+                new PlayListCreateDto(1L, 1L, "", "", LocalDateTime.now().toString())
+        );
+        PlayListCreateResponse dto = new PlayListCreateResponse("스냅샷 키", list);
+
+        doThrow(new DataAccessResourceFailureException("데이터베이스 접근 에러"))
+                .doNothing()
+                .when(bulkRepository).bulkInsert(list);
+
+        asyncService.bulkInsertAsync(dto);
+
+        // when
+        asyncService.retryFallbackCache();
+
+        // then
+        assertThat(asyncService.getFallbackCache()).isEmpty();
+        verify(bulkRepository, times(2)).bulkInsert(list);
+        verify(redisHashService).deleteSnapshot("스냅샷 키");
+    }
+}

--- a/src/test/java/com/naver/playlist/PlayListItemGetTest.java
+++ b/src/test/java/com/naver/playlist/PlayListItemGetTest.java
@@ -1,0 +1,126 @@
+package com.naver.playlist;
+
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.dto.playlist.res.PlayListItemResponse;
+import com.naver.playlist.domain.dto.playlist.res.PlayListResponse;
+import com.naver.playlist.domain.entity.member.Member;
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.naver.playlist.domain.redis.RedisPlayListService;
+import com.naver.playlist.domain.repository.MemberRepository;
+import com.naver.playlist.domain.repository.MusicRepository;
+import com.naver.playlist.domain.repository.PlayListRepository;
+import com.naver.playlist.domain.service.PlayListItemService;
+import com.naver.playlist.domain.service.PlayListService;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.naver.playlist.domain.constant.EntityConstants.MAX_PLAY_PAGE_SIZE;
+import static com.naver.playlist.web.exception.ExceptionType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest()
+public class PlayListItemGetTest extends ServiceTest {
+
+    @Autowired
+    private PlayListRepository playListRepository;
+
+    @Autowired
+    private PlayListItemService playListItemService;
+
+    @Autowired
+    private PlayListService playListService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MusicRepository musicRepository;
+
+    @Autowired
+    private RedisPlayListService redisPlayListService;
+
+    private Member 회원1;
+    private PlayList 플레이리스트1;
+    private PlayList 플레이리스트2;
+    List<PlayListItem> 플레이리스트1아이템;
+
+    @BeforeEach
+    public void setUp() throws InterruptedException {
+        회원1 = memberRepository.save(new Member("이름"));
+        플레이리스트1 = playListRepository.save(new PlayList("제목1", "설명1", 회원1));
+        플레이리스트2 = playListRepository.save(new PlayList("제목2", "설명2", 회원1));
+        for (int i = 0; i < 100; i++) {
+            Music 음악 = musicRepository.save(new Music("음악" + i));
+            playListItemService.create(플레이리스트1.getId(), 회원1.getId(), 음악);
+        }
+        flushAndClear();
+        플레이리스트1 = playListRepository.findById(플레이리스트1.getId()).get();
+        플레이리스트1아이템 = 플레이리스트1.getPlayListItemList();
+    }
+
+    @Test
+    @DisplayName("1. 플레이리스트에 조회 - 플레이리스트는 페이지 단위로 조회된다.")
+    void 플레이리스트는_페이지_단위로_조회된다() throws InterruptedException {
+        //given when
+        PlayListResponse 플레이리스트1_페이지1 = playListService.get(this.플레이리스트1.getId(), null);
+        PlayListResponse 플레이리스트2_페이지1 = playListService.get(this.플레이리스트2.getId(), null);
+
+        // then
+        assertThat(플레이리스트1_페이지1.isHasNext()).isEqualTo(true);
+        assertThat(플레이리스트1_페이지1.getPlayListItems().size()).isEqualTo(MAX_PLAY_PAGE_SIZE);
+
+        assertThat(플레이리스트2_페이지1.isHasNext()).isEqualTo(false);
+        assertThat(플레이리스트2_페이지1.getPlayListItems().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("2. 플레이리스트에 조회 - 플레이리스트는 끝 페이지까지 조회할수있다.")
+    void 플레이리스트_마지막_페이지까지_조회() throws InterruptedException {
+        //given when
+        Long 커서 = null;
+        for (int i = 0; i < 5; i++) {
+            PlayListResponse 페이지 = playListService.get(this.플레이리스트1.getId(), 커서);
+            List<PlayListItemResponse> 페이지아이템 = 페이지.getPlayListItems();
+            커서 = 페이지아이템.get(페이지아이템.size()-1).getOrder();
+
+            // then
+            assertThat(페이지.isHasNext()).isEqualTo(i == 4 ? false : true);
+            assertThat(페이지.getPlayListItems().size()).isEqualTo(MAX_PLAY_PAGE_SIZE);
+        }
+    }
+
+    @Test
+    @DisplayName("3. 플레이리스트에 조회 - 플레이리스트 조회시 캐시에 저장된다.")
+    void 플레이리스트_조회시_캐시에_저장된다() throws InterruptedException {
+        //given when
+        PlayListResponse 플레이리스트1_페이지1 = playListService.get(this.플레이리스트1.getId(), null);
+
+        //when
+        PlayListResponse 캐시_존재 = redisPlayListService.getPlayList(플레이리스트1.getId(), null);
+        PlayListResponse 캐시_미존재 = redisPlayListService.getPlayList(1L, null);
+
+        //then
+        assertThat(캐시_미존재).isNull();
+        assertThat(캐시_존재).isNotNull();
+        List<PlayListItemResponse> 플레이리스트아이템 = 플레이리스트1_페이지1.getPlayListItems();
+        for (int i = 0; i < 플레이리스트아이템.size(); i++) {
+            PlayListItemResponse DB_아이템 = 플레이리스트아이템.get(i);
+            PlayListItemResponse 캐시_아이템 = 플레이리스트아이템.get(i);
+            assertThat(DB_아이템.getId()).isEqualTo(캐시_아이템.getId());
+        }
+    }
+}

--- a/src/test/java/com/naver/playlist/PlayListItemReOrderTest.java
+++ b/src/test/java/com/naver/playlist/PlayListItemReOrderTest.java
@@ -1,0 +1,137 @@
+package com.naver.playlist;
+
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.entity.member.Member;
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.naver.playlist.domain.repository.MemberRepository;
+import com.naver.playlist.domain.repository.MusicRepository;
+import com.naver.playlist.domain.repository.PlayListRepository;
+import com.naver.playlist.domain.service.PlayListItemService;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.naver.playlist.web.exception.ExceptionType.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest()
+public class PlayListItemReOrderTest extends ServiceTest {
+
+    @Autowired
+    private PlayListRepository playListRepository;
+
+    @Autowired
+    private PlayListItemService playListItemService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private MusicRepository musicRepository;
+
+    private Member 회원1;
+    private PlayList 플레이리스트;
+    List<PlayListItem> 플레이리스트아이템;
+
+    @BeforeEach
+    public void setUp() throws InterruptedException {
+        회원1 = memberRepository.save(new Member("이름"));
+        플레이리스트 = playListRepository.save(new PlayList("제목", "설명", 회원1));
+        for (int i = 0; i < 10; i++) {
+            Music 음악 = musicRepository.save(new Music("음악" + i));
+            playListItemService.create(플레이리스트.getId(), 회원1.getId(), 음악);
+        }
+        flushAndClear();
+        플레이리스트 = playListRepository.findById(플레이리스트.getId()).get();
+        플레이리스트아이템 = 플레이리스트.getPlayListItemList();
+    }
+
+    @Test
+    @DisplayName("1. 플레이리스트에 순서 변경 - 엣지 케이스 - 플레이리스트에 없는 노래는 순서를 바꿀 수 없다.")
+    void 플레이리스트에_존재하는_노래만_순서를_바꿀수있다() {
+        //given when then
+        PlayListException 예외 = assertThrows(PlayListException.class, () -> {
+            playListItemService.reorder(
+                    플레이리스트.getId(),
+                    회원1.getId(),
+                    List.of(
+                            new ReorderPlayListItemsRequest(1L, 1000L)
+                    )
+            );
+        });
+
+        assertEquals(PLAY_LIST_ITEM_NOT_EXIST.getCode(), 예외.getCode());
+        assertEquals(PLAY_LIST_ITEM_NOT_EXIST.getErrorMessage(), 예외.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("2. 플레이리스트에 순서 변경 - 엣지 케이스 - 플레이리스트 ID와 아이템이 가지는 플레이리스트 아이템의 ID가 다르면 안된다.")
+    void 수정할_플레이리스트_ID와_아이템이_가진_플레이리스트_ID가_다르면_안된다() {
+        //given when then
+        PlayListException 예외 = assertThrows(PlayListException.class, () -> {
+            playListItemService.reorder(
+                    1L,
+                    회원1.getId(),
+                    List.of(
+                            new ReorderPlayListItemsRequest(플레이리스트아이템.get(0).getId(), 1000L)
+                    )
+            );
+        });
+
+        assertEquals(PLAY_LIST_NOT_MATCH_ITEM.getCode(), 예외.getCode());
+        assertEquals(PLAY_LIST_NOT_MATCH_ITEM.getErrorMessage(), 예외.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("3. 플레이리스트에 순서 변경 - 엣지 케이스 - 플레이리스트 생성 회원만 플레이리스트를 수정할 수 있다.")
+    void 플레이리스트_생성_회원만_플레이리스트를_수정할수있다() {
+        //given when then
+        PlayListException 예외 = assertThrows(PlayListException.class, () -> {
+            playListItemService.reorder(
+                    플레이리스트.getId(),
+                    1L,
+                    List.of(
+                            new ReorderPlayListItemsRequest(플레이리스트아이템.get(0).getId(), 1000L)
+                    )
+            );
+        });
+
+        assertEquals(PLAY_LIST_AUTH_INVALID.getCode(), 예외.getCode());
+        assertEquals(PLAY_LIST_AUTH_INVALID.getErrorMessage(), 예외.getErrorMessage());
+    }
+
+    @Test
+    @DisplayName("4. 플레이리스트에 순서 변경 -  플레이리스트 순서를 변경할수있다")
+    void 플레이리스트_순서변경() {
+        //given when then
+        assertDoesNotThrow(() -> {
+                playListItemService.reorder(
+                        플레이리스트.getId(),
+                        회원1.getId(),
+                        List.of(
+                                new ReorderPlayListItemsRequest(플레이리스트아이템.get(0).getId(), 1000L),
+                                new ReorderPlayListItemsRequest(플레이리스트아이템.get(1).getId(), 2000L)
+                        )
+                );
+        });
+    }
+}

--- a/src/test/java/com/naver/playlist/mock/PlayListAsyncMockServiceTest.java
+++ b/src/test/java/com/naver/playlist/mock/PlayListAsyncMockServiceTest.java
@@ -1,4 +1,4 @@
-package com.naver.playlist;
+package com.naver.playlist.mock;
 
 import com.naver.playlist.domain.dto.playlist.res.PlayListCreateResponse;
 import com.naver.playlist.domain.dto.redis.PlayListCreateDto;
@@ -20,8 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class PlayListAsyncServiceTest {
-
+public class PlayListAsyncMockServiceTest {
 
     @Mock JdbcBulkRepository bulkRepository;
     @Mock RedisHashService redisHashService;

--- a/src/test/java/com/naver/playlist/mock/PlayListItemMockServiceTest.java
+++ b/src/test/java/com/naver/playlist/mock/PlayListItemMockServiceTest.java
@@ -1,0 +1,106 @@
+package com.naver.playlist.mock;
+
+import com.naver.playlist.ServiceTest;
+import com.naver.playlist.domain.dto.playlist.req.ReorderPlayListItemsRequest;
+import com.naver.playlist.domain.dto.playlist.res.PlayListReOrderResponse;
+import com.naver.playlist.domain.entity.member.Member;
+import com.naver.playlist.domain.entity.music.Music;
+import com.naver.playlist.domain.entity.playlist.PlayList;
+import com.naver.playlist.domain.entity.playlist.PlayListItem;
+import com.naver.playlist.domain.repository.*;
+import com.naver.playlist.domain.service.PlayListItemService;
+import com.naver.playlist.web.exception.entity.PlayListException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.naver.playlist.web.exception.ExceptionType.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@Transactional
+@ActiveProfiles("test")
+@SpringBootTest()
+public class PlayListItemMockServiceTest extends ServiceTest {
+
+    @Autowired
+    private PlayListItemRepository playListItemRepository;
+
+    @Autowired
+    private PlayListRepository playListRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RedissonClient redisson;
+
+    @Autowired
+    private MusicRepository musicRepository;
+
+    private PlayListItemService playListItemService;
+
+    @Mock
+    JdbcBulkRepository bulkRepository;
+
+    private Member 회원1;
+    private PlayList 플레이리스트;
+    List<PlayListItem> 플레이리스트아이템;
+
+    @BeforeEach
+    public void setUp() throws InterruptedException {
+        playListItemService = new PlayListItemService(
+                bulkRepository,
+                playListItemRepository,
+                playListRepository,
+                redisson
+        );
+
+        회원1 = memberRepository.save(new Member("이름"));
+        플레이리스트 = playListRepository.save(new PlayList("제목", "설명", 회원1));
+        for (int i = 0; i < 10; i++) {
+            Music 음악 = musicRepository.save(new Music("음악" + i));
+            playListItemService.create(플레이리스트.getId(), 회원1.getId(), 음악);
+        }
+        flushAndClear();
+        플레이리스트 = playListRepository.findById(플레이리스트.getId()).get();
+        플레이리스트아이템 = 플레이리스트.getPlayListItemList();
+    }
+
+    @Test
+    @DisplayName("1. 데이터베이스 접근 예외 - 순서 중복 시 리오더링이 발생한다.")
+    void 플레이리스트에_존재하는_노래만_순서를_바꿀수있다() {
+        //given
+        List<ReorderPlayListItemsRequest> request = List.of(
+                new ReorderPlayListItemsRequest(플레이리스트아이템.get(0).getId(), 1000L),
+                new ReorderPlayListItemsRequest(플레이리스트아이템.get(1).getId(), 2000L)
+        );
+
+        doThrow(new DuplicateKeyException("키 중복 에러"))
+                .doNothing()
+                .when(bulkRepository).bulkUpdatePosition(any());
+
+        //when
+        PlayListReOrderResponse result = playListItemService.reorder(
+                플레이리스트.getId(),
+                회원1.getId(),
+                request
+        );
+
+        verify(bulkRepository, times(2)).bulkUpdatePosition(any());
+        assertThat(result.isSuccess()).isEqualTo(false);
+        assertThat(result.getPlayListItems().size()).isEqualTo(10);
+    }
+}


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 플레이리스트 벌크 인서트 예외처리
- [x] 테스트 코드 작성

## 고민과 해결과정

### 1️⃣ 데이터베이스 장애 시 대처
플레이리스트 벌크 인서트는 일반적인 데이터베이스 장애 처리 방식과 다르게 동작한다.
벌크 업데이트 전, 캐시로부터 데이터를 가져올 때는 스냅샷을 생성한 후 원본 데이터를 초기화한다. 
이때 만약 벌크 인서트 작업이 데이터베이스 문제로 인해 실패했다고 해보자
그렇다면 스냅샷이 보관되지 않은 상태에서는 해당 데이터가 TTL에 의해 자동으로 삭제될 수 있다.
이를 방지하기 위해 벌크 인서트 과정에서는 데이터베이스 장애 발생 시, 실패한 작업의 스냅샷 키를 별도로 보관한다.
이후 스케줄링을 통해 재시도한다.

```java

@Getter
private final Map<String, List<PlayListCreateDto>> fallbackCache = new ConcurrentHashMap<>();

@Async
@Transactional
public void bulkInsertAsync(PlayListCreateResponse dto) {
    try {
        bulkRepository.bulkInsert(dto.getPlayList());
        redisHashService.deleteSnapshot(dto.getKey());
    } catch (DataAccessResourceFailureException e) {
        fallbackCache.put(dto.getKey(), dto.getPlayList());
    }
}
```


### 2️⃣ 캡슐화와 MOCK사이의 적용 범위를 결정해야 한다
비즈니스 로직에서는 기본적으로 MOCK을 사용하지 않는 것을 선호한다.
다만 데이터베이스나 레디스아 이런 곳에서 장애가 났다는 것을 가정할 경우
MOCK을 사용할 수 밖에 없다.
하지만 비즈니스 로직이 너무 긴 경우 MOCK을 사용하면 코드가 너무 복잡해진다.

```java
 /* 플레이리스트 노래 순서 변경 메서드 */
public PlayListReOrderResponse reorder(
        Long playListId,
        Long memberId,
        List<ReorderPlayListItemsRequest> dto
) {
    // 1️⃣ 조회할 아이디 추출
    List<Long> ids = extractIds(dto);

    // 2️⃣ 페치조인 + IN 쿼리 조회 - PlayListItem + PlayList + Member
    List<PlayListItem> playListItems =
            playListItemRepository.findPlayListItemForUpdate(ids);

    // 3️⃣ 개수 불일치 → 일부 곡이 존재하지 않음
    validateExistence(dto, playListItems);

    // 4️⃣ 플레이리스트 ID 검증 (모든 곡이 같은 플레이리스트 소속인지)
    validatePlayList(playListId, playListItems);

    // 5️⃣ 멤버 검증 (해당 플레이리스트 소유자인지)
    validateMember(memberId, playListItems.get(0).getPlayList());

    // 6️⃣ 벌크 업데이트 - 실패시 전체 재오더링, 예외를 던지는 이유는 리렌더링 후 클라이언트에서 재조정해야하기 때문
    return bulkUpdate(dto, playListId);
}

private PlayListReOrderResponse bulkUpdate(
        List<ReorderPlayListItemsRequest> dto,
        Long playListId
) {
    try {
        jdbcBulkRepository.bulkUpdatePosition(dto);
        return new PlayListReOrderResponse(true, dto);
    } catch (DuplicateKeyException ex) {
        List<ReorderPlayListItemsRequest> reorderList = reorderingPositions(playListId);
        jdbcBulkRepository.bulkUpdatePosition(reorderList);
        return new PlayListReOrderResponse(false, reorderList);
    }
}
```

위와 같은 로직이 있다고 해보자.
만약 전체적으로 MOCK을 적용한다면 하나하나 다 어떻게 설정해야하는지 결정해야 한다.
그렇다고 부분 MOCK을 위해 bulkUpdate의 캡슐화를 제거하는 것도 좋은 선택은 아니다.
따라서 내가 선택한 방식은 기본 비즈니스 로직을 실행하면서 MOCK을 적용하고 싶은 범위만 MOCK으로 한다.

```java
@Autowired
private PlayListItemRepository playListItemRepository;

@Autowired
private PlayListRepository playListRepository;

@Autowired
private RedissonClient redisson;

@Mock
JdbcBulkRepository bulkRepository;

private PlayListItemService playListItemService;

@BeforeEach
public void setUp() throws InterruptedException {
    playListItemService = new PlayListItemService(
            bulkRepository,
            playListItemRepository,
            playListRepository,
            redisson
    );
}
```

즉, 이렇게 MOCK을 정의하는 범위를 최소화하고 비즈니스 로직과 함께 실행시킴으로서
코드의 복잡도를 줄일수 있다.