### PR TITLE
[Fix] JDBC 배치 활성화

### DIFF
--- a/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
+++ b/src/main/java/com/naver/playlist/domain/entity/playlist/PlayListItem.java
@@ -25,12 +25,6 @@ import org.hibernate.annotations.Comment;
                         name = "uk_playlist_position",
                         columnNames = { "playListId", "position" }
                 )
-        },
-        indexes = {
-            @Index(
-                    name = "idx_playlist_position",
-                    columnList = "playListId, position"
-            )
         }
 )
 public class PlayListItem extends BaseEntity {

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/playlist}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/playlist?rewriteBatchedStatements=true}
     username: ${SPRING_DATASOURCE_USERNAME:playlist}
     password: ${SPRING_DATASOURCE_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/playlist}
+    url: ${SPRING_DATASOURCE_URL:jdbc:mysql://localhost:3306/playlist?rewriteBatchedStatements=true}
     username: ${SPRING_DATASOURCE_USERNAME:playlist}
     password: ${SPRING_DATASOURCE_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## ✅ 완료한 기능 명세
- [x] 불필요한 중복 인덱스 제거
- [x] 배치 쿼리 rewirte 활성화

## 고민과 해결과정

### 배치 쿼리에 rewrite를 쓰는 이유

[문서화](https://jseungmin.notion.site/JDBC-1f7e2fd91ae28087a4a5cff713c4573c?pvs=4)

배치 쿼리에 rewrite를 쓰지 않으면 JDBC 벌크 인서트라도 개별 쿼리가 진행된다.
즉, 1000개의 데이터를 수정할때 1000개의 네트워크 레이턴시가 발생하는 것이다.
따라서 rewrite 모드를 활성화하여 제대로 JDBC 벌크 인서트를 사용해야 한다
